### PR TITLE
Support bill additions and removals across paragraphs

### DIFF
--- a/assets/javascripts/lib/discourse-markdown/discourse-tsp-markdown.js
+++ b/assets/javascripts/lib/discourse-markdown/discourse-tsp-markdown.js
@@ -57,6 +57,14 @@ function setupMarkdownIt(md) {
          return true;
       }
    });
+   block_ruler.push("add", {
+      tag: "add",
+      wrap: "div.markdown-bill-add",
+   });
+   block_ruler.push("remove", {
+      tag: "remove",
+      wrap: "div.markdown-bill-remove",
+    });
 }
 export function setup(helper) {
    if(!helper.markdownIt) { return; }
@@ -70,6 +78,8 @@ export function setup(helper) {
       'div.markdown-bill',
       'span.markdown-bill-add',
       'span.markdown-bill-remove',
+      'div.markdown-bill-add',
+      'div.markdown-bill-remove',
       'div[style=*]',
       'tr[align=*]',
       'tr[style=*]',


### PR DESCRIPTION
This PR adds support for using [add] and [remove] tags across paragraphs. They currently only work 'inline' and don't work if their contents span multiple paragraphs.