### PR TITLE
Include bill add and remove styles

### DIFF
--- a/assets/stylesheets/common/bills.scss
+++ b/assets/stylesheets/common/bills.scss
@@ -1,0 +1,8 @@
+.markdown-bill-add {
+  color: rgb(39, 174, 96) !important;
+}
+
+.markdown-bill-remove {
+  color: rgb(255, 0, 0) !important;
+  text-decoration: line-through !important;
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -3,3 +3,4 @@
 # version: 0.0.1
 # authors: Dylan Henrich
 
+register_asset "stylesheets/common/bills.scss"


### PR DESCRIPTION
This PR includes the styles for [add] and [remove] tags in the plugin itself. The plugin already applies the CSS classes for the HTML elements generated by these tags, but the actual CSS styles aren't included in the plugin — they seem to be a custom modification to the default theme on the TSP forums (and don't work when using the Fully theme, for instance). Given that the CSS classes are added by this plugin, I think it's sensible to also include the styles for those classes in the same plugin.